### PR TITLE
Add CI pipeline — install and startup check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18, 20]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Verify app starts
+        run: |
+          node -e "require('./app.js')" &
+          sleep 3
+          curl --fail http://localhost:3000 || exit 1
+          kill %1


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions CI workflow that runs on pushes to `main` and on PRs
- Tests against Node.js 18 and 20
- Verifies `yarn install --frozen-lockfile` succeeds (dependency integrity)
- Verifies the app starts and responds on port 3000 (basic smoke test)

## Test plan
- [ ] Merge and confirm the workflow runs green on the PR itself